### PR TITLE
Feat: Refactor Routes

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,12 +1,11 @@
 import express from 'express';
 import dotenv from 'dotenv';
 
+/* ROUTES */
+import routes from "./routes"
+
 /* MIDDLEWARE */
 import { errorHandler } from './middleware/errorHandler';
-
-/* ROUTES */
-import itemRoutes from './routes/itemRoutes';
-import attributeRoutes from './routes/attributeRoutes';
 
 /* ********************************** */
 /*              ENV CONFIG            */
@@ -15,25 +14,19 @@ dotenv.config();
 const PORT = process.env.PORT || 3000;
 
 /* CONFIG */
-const app = express();
+const api = express();
 
 /* ********************************** */
 /*              MIDDLEWARE            */
 /* ********************************** */
-app.use(express.json());
-app.use(express.static('public'));
-
-
-/* ********************************** */
-/*                ROUTES              */
-/* ********************************** */
-app.use('/api/items', itemRoutes);
-app.use('/api/attributes', attributeRoutes);
+api.use(express.json());
+api.use(express.static('public'));
+api.use(routes);
 
 /* ********************************** */
 /*           ERROR HANDLER            */
 /* ********************************** */
-app.use(errorHandler);
+api.use(errorHandler);
 
 /*
  * Error handler middleware must be declared after all routes
@@ -41,6 +34,6 @@ app.use(errorHandler);
 */
 
 /* SERVE ~ */
-app.listen(PORT, () => {
+api.listen(PORT, () => {
   console.log(`API is listening on port: ${PORT}`);
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import itemRoutes from "./itemRoutes";
+import attributeRoutes from "./attributeRoutes";
+
+const router = Router();
+
+router.use('/api/items', itemRoutes);
+router.use('/api/attributes', attributeRoutes);
+
+export default router;

--- a/src/routes/itemRoutes.ts
+++ b/src/routes/itemRoutes.ts
@@ -4,6 +4,12 @@ import {
   postItem as postItemController
 } from '../controllers/itemController';
 
+/*
+ * consider this file as the singular router than handles
+ * the import and export of all routes in the api into
+ * the main api
+*/
+
 const router = Router();
 
 router


### PR DESCRIPTION
### Refactors express `routes` with a singular export
1. Creates an `index.ts` in routes that handles the import and export of all routes
2. _uses_ `index.ts` as default `routes` export in `api.ts`
3. Renames `app` instance of express to `api`